### PR TITLE
Set a WorkingDirectory

### DIFF
--- a/templates/coredns.service.j2
+++ b/templates/coredns.service.j2
@@ -14,6 +14,7 @@ LimitNPROC=512
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true
+WorkingDirectory=/etc/coredns
 
 User={{ coredns_system_user }}
 Group={{ coredns_system_group }}


### PR DESCRIPTION
Set the WorkingDirectory in systemd unit to /etc/coredns to make zone
file relative paths work.

[patch]

Signed-off-by: Ben Kochie <superq@gmail.com>