### PR TITLE
Add option to deploy dnssec keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ All variables which can be overridden are stored in [defaults/main.yml](defaults
 
 | Name                         | Default Value  | Description                        |
 | ---------------------------- | -------------- | -----------------------------------|
-| `coredns_version` | 1.8.3          | CoreDNS package version |
-| `coredns_binary_local_dir` | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `coredns` binary is stored on host on which ansible is ran. This overrides `coredns_version` parameter |
+| `coredns_version`            | 1.8.3          | CoreDNS package version |
+| `coredns_binary_local_dir`   | "" | Allows to use local packages instead of ones distributed on github. As parameter it takes a directory where `coredns` binary is stored on host on which ansible is ran. This overrides `coredns_version` parameter |
 | `coredns_dns_port`           | 53             | Port on which CoreDNS will listen for DNS requests |
 | `coredns_config_file`        |                | This should contain path to file with coredns configuration [Corefile](https://coredns.io/manual/toc/#configuration) |
-| `coredns_zone_files_paths`        | ["coredns/zones/*"] | List containing paths to zone files
+| `coredns_key_files_paths`    | `["coredns/keys/*"]`  | List containing paths to dnssec key files
+| `coredns_zone_files_paths`   | `["coredns/zones/*"]` | List containing paths to zone files
 
 ## Example
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,6 @@ coredns_binary_local_dir: ""
 
 coredns_zone_files_paths:
   - "coredns/zones/*"
+
+coredns_key_files_paths:
+  - "coredns/keys/*"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,15 @@
     mode: 0644
   notify: restart coredns
 
+- name: Copy key files
+  template:
+    src: "{{ item }}"
+    dest: /etc/coredns/keys
+    owner: "{{ coredns_system_user }}"
+    group: "{{ coredns_system_group }}"
+    mode: 0400
+  with_fileglob: "{{ coredns_key_files_paths }}"
+
 - name: Copy zone files
   template:
     src: "{{ item }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
     mode: 0755
   with_items:
     - /etc/coredns
+    - /etc/coredns/keys
     - /etc/coredns/zones
 
 - block:


### PR DESCRIPTION
Add a template to deploy dnssec key files
* Owned by CoreDNS user.
* Read-only for just the CoreDNS user.

Signed-off-by: SuperQ <superq@gmail.com>